### PR TITLE
Return interaction improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@
 /classes
 /target
 /external
+*.iml
+/.idea

--- a/resources/templates/customer.html
+++ b/resources/templates/customer.html
@@ -27,11 +27,11 @@
     </thead>
     <tbody>
       {% for rental in current_rentals %}
-      <tr>
+      <tr class="rental-row">
 	<td>{{ rental.id }}</td>
 	<td>{{ rental.title }}</td>
 	<td>{{ rental.rental_date }}</td>
-	<td><button hx-delete="/rentals/{{ rental.id }}">Return</button></td>
+	<td><button hx-delete="/rentals/{{ rental.id }}" hx-target="closest .rental-row">Return</button></td>
       </tr>
       {% endfor %}
     </tbody>

--- a/resources/templates/customer.html
+++ b/resources/templates/customer.html
@@ -31,14 +31,21 @@
 	<td>{{ rental.id }}</td>
 	<td>{{ rental.title }}</td>
 	<td>{{ rental.rental_date }}</td>
-	<td><button hx-delete="/rentals/{{ rental.id }}" hx-target="closest .rental-row">Return</button></td>
+	<td>
+        <form>
+            <input name="return-date" type="date" />
+            <button hx-delete="/rentals/{{ rental.id }}"
+                    hx-on--before-cleanup-element="htmx.trigger('#historic-rentals', 'refresh')"
+                    hx-target="closest .rental-row">Return</button>
+        </form>
+    </td>
       </tr>
       {% endfor %}
     </tbody>
   </table>
 </section>
 
-<section style="max-height: 30vh; overflow-y: auto">
+<section style="max-height: 30vh; overflow-y: auto" id="historic-rentals" hx-get="" hx-select="#historic-rentals" hx-trigger="refresh">
   <h2>Historic Rentals</h2>
   <table>
     <thead>

--- a/resources/templates/rentals.html
+++ b/resources/templates/rentals.html
@@ -21,7 +21,12 @@
 	<td>{{ rental.rental_date }}</td>
 	<td>{{ rental.first_name }} {{ rental.last_name }}</td>
 	<td>{{ rental.film }}</td>
-	<td><button hx-delete="/rentals/{{ rental.id }}" hx-target="closest .rental-row">Delete</button></td>
+	<td>
+        <form>
+            <input type="date" name="return-date" />
+            <button hx-delete="/rentals/{{ rental.id }}" hx-target="closest .rental-row">Delete</button>
+        </form>
+    </td>
       </tr>
       {% endfor %}
     </tbody>

--- a/resources/templates/rentals.html
+++ b/resources/templates/rentals.html
@@ -16,12 +16,12 @@
     </thead>
     <tbody>
       {% for rental in rentals %}
-      <tr>
+      <tr class="rental-row">
 	<td>{{ rental.id }}</td>
 	<td>{{ rental.rental_date }}</td>
 	<td>{{ rental.first_name }} {{ rental.last_name }}</td>
 	<td>{{ rental.film }}</td>
-	<td><button hx-delete="/rentals/{{ rental.id }}">Delete</button></td>
+	<td><button hx-delete="/rentals/{{ rental.id }}" hx-target="closest .rental-row">Delete</button></td>
       </tr>
       {% endfor %}
     </tbody>

--- a/src/xtdb/demo/resources.clj
+++ b/src/xtdb/demo/resources.clj
@@ -107,7 +107,7 @@
                      :xtql (q '(unify (from :film [{:xt/id $film-id} title description language_id release_year rating])
                                       (from :language [{:xt/id language_id} {:name language}]))
                               {:args {:film-id (Long/parseLong id)}
-                               :key-fn :snake_case})))]
+                               :key-fn :snake-case-kw})))]
          film)}})))
 
 (defn customers-table [_]

--- a/src/xtdb/demo/resources.clj
+++ b/src/xtdb/demo/resources.clj
@@ -184,7 +184,7 @@
                     (from :film [{:xt/id film_id} title]))
              (order-by {:val rental_date :dir :desc}))
            {:args {:customer_id customer-id}
-            :key-fn :snake_case})]
+            :key-fn :snake-case-kw})]
     (html-templated-resource
      {:template "templates/customer.html"
       :template-model
@@ -196,7 +196,7 @@
          '(unify (from :customer [{:xt/id $customer_id} {:xt/id id} first_name last_name email address_id])
                  (from :address [{:xt/id address_id} phone]))
          {:args {:customer_id customer-id}
-          :key-fn :snake_case}))
+          :key-fn :snake-case-kw}))
 
        "current_rentals"
        (q '(unify (from :rental {:bind [{:xt/id rental_id} {:xt/id id} {:customer-id $customer_id} inventory_id {:xt/valid-from rental_date}]})
@@ -204,7 +204,7 @@
                   (from :inventory [{:xt/id inventory_id} film_id])
                   (from :film [{:xt/id film_id} title]))
           {:args {:customer_id customer-id}
-           :key-fn :snake_case}
+           :key-fn :snake-case-kw}
           )
 
        "historic_rentals"
@@ -250,7 +250,7 @@
                           (from :inventory [{:xt/id inventory_id} film_id])
                           (from :film [{:xt/id film_id} {:title film}]))
                   {:args {:customer_id 560}
-                   :key-fn :snake_case})}}))
+                   :key-fn :snake-case-kw})}}))
 
 (defn ^{:uri-template "rentals/{id}"} rental [{:keys [path-params]}]
   (let [rental-id (Long/parseLong (get path-params "id"))]

--- a/src/xtdb/demo/resources.clj
+++ b/src/xtdb/demo/resources.clj
@@ -108,7 +108,7 @@
                                       (from :language [{:xt/id language_id} {:name language}]))
                               {:args {:film-id (Long/parseLong id)}
                                :key-fn :snake-case-kw})))]
-         film)}})))
+         (assoc film :id id))}})))
 
 (defn customers-table [_]
   (let [customers (fn [request]

--- a/src/xtdb/demo/resources.clj
+++ b/src/xtdb/demo/resources.clj
@@ -263,7 +263,8 @@
           (xt/submit-tx
            (:xt-node xt-node)
            [(xt/delete :rental rental-id)])
-          {})}}})))
+          ;; returning 204 causes HTMX to not swap, even if a hx-swap=delete is set.
+          {:ring.response/status 200})}}})))
 
 (defn analytics [_]
   (let [rows (xt/q (:xt-node xt-node)

--- a/src/xtdb/demo/web/request.clj
+++ b/src/xtdb/demo/web/request.clj
@@ -37,7 +37,7 @@
     ;; your resource.
     (let [max-content-length
           (or
-           (get-in resource [:methods (case method :put "PUT" :post "POST") :max-content-length])
+           (get-in resource [:methods (case method :put "PUT" :post "POST" :delete "DELETE") :max-content-length])
            (Math/pow 2 24) ;;16MB
            )]
       (when (> content-length max-content-length)
@@ -64,7 +64,7 @@
 
     (let [acceptable-content-types
           (set (get-in resource [:methods
-                                 (case method :put "PUT" :post "POST")
+                                 (case method :put "PUT" :post "POST" :delete "DELETE")
                                  :accept]))
           parsed-request-content-type ((:header-reader req) "content-type")
           request-content-type (str (:juxt.reap.rfc7231/type parsed-request-content-type)

--- a/test/xtdb/demo/web/data_test.clj
+++ b/test/xtdb/demo/web/data_test.clj
@@ -80,6 +80,3 @@
           EXTRACT (MONTH FROM rental.xt$valid_from) as month
    FROM rental FOR ALL VALID_TIME")
          )))
-
-(xt/q (:xt-node xt-node)
-      )

--- a/test/xtdb/demo/web/data_test.clj
+++ b/test/xtdb/demo/web/data_test.clj
@@ -42,7 +42,7 @@
                 (from :inventory [{:xt/id inventory_id} film_id])
                 (from :film [{:xt/id film_id} title]))
         {:args {:customer_id 560}
-         :key-fn :snake_case}))
+         :key-fn :snake-case-kw}))
 
 (comment
   (for [result
@@ -63,7 +63,7 @@
                 (from :inventory [{:xt/id inventory_id} film_id])
                 (from :film [{:xt/id film_id} title]))
         {:args {:customer_id 560}
-         :key-fn :snake_case})
+         :key-fn :snake-case-kw})
 
   (xt/delete :rental 14425))
 


### PR DESCRIPTION
Some improvements to rental interactions

- Returns accept a return date (assumed Europe/London)
- Return interactions delete the return row on both the customer page and rentals page once deleted in the database.
- Return interaction now refreshes the return history

Requires updated XTDB 2.x support to `60ee84b0`, can do a separate PR if wanted.
